### PR TITLE
LPS X InetAddressUtil 2

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -40,11 +40,8 @@ public class InetAddressUtil {
 	public static InetAddress getInetAddressByName(String domain)
 		throws UnknownHostException {
 
-		AtomicInteger atomicInteger = new AtomicInteger(
-			_DNS_SECURITY_THREAD_LIMIT);
-
 		try {
-			if (atomicInteger.getAndDecrement() <= 0) {
+			if (_atomicInteger.getAndDecrement() <= 0) {
 				_log.error(
 					"Thread limit exceeded to resolve domain: " + domain);
 
@@ -76,7 +73,7 @@ public class InetAddressUtil {
 				"Unable to resolve domain: " + domain);
 		}
 		finally {
-			atomicInteger.incrementAndGet();
+			_atomicInteger.incrementAndGet();
 		}
 	}
 
@@ -130,11 +127,12 @@ public class InetAddressUtil {
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS));
 
-	private static final int _DNS_SECURITY_THREAD_LIMIT = GetterUtil.getInteger(
-		PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT));
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		InetAddressUtil.class);
+
+	private static final AtomicInteger _atomicInteger = new AtomicInteger(
+		GetterUtil.getInteger(
+			PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)));
 
 	private static class LocalHostNameHolder {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.util;
 
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -24,6 +25,8 @@ import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
 import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.SynchronousQueue;
@@ -41,24 +44,32 @@ public class InetAddressUtil {
 	public static InetAddress getInetAddressByName(String domain)
 		throws UnknownHostException {
 
-		try {
-			DNSResolveTask dnsResolveTask = new DNSResolveTask(domain);
+		return _resolvedAddresses.computeIfAbsent(
+			domain,
+			key -> {
+				try {
+					DNSResolveTask dnsResolveTask = new DNSResolveTask(key);
 
-			_threadPoolExecutor.execute(dnsResolveTask);
+					_threadPoolExecutor.execute(dnsResolveTask);
 
-			return dnsResolveTask.get(
-				_DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-		}
-		catch (ExecutionException | InterruptedException | TimeoutException
-					exception) {
+					return dnsResolveTask.get(
+						_DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS,
+						TimeUnit.SECONDS);
+				}
+				catch (ExecutionException | InterruptedException |
+					   TimeoutException exception) {
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
+					if (_log.isDebugEnabled()) {
+						_log.debug(exception);
+					}
 
-			throw new UnknownHostException(
-				"Unable to resolve domain: " + domain);
-		}
+					ReflectionUtil.throwException(
+						new UnknownHostException(
+							"Unable to resolve domain: " + key));
+
+					return null;
+				}
+			});
 	}
 
 	public static String getLocalHostName() throws Exception {
@@ -113,6 +124,9 @@ public class InetAddressUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		InetAddressUtil.class);
+
+	private static final Map<String, InetAddress> _resolvedAddresses =
+		new ConcurrentHashMap<>();
 
 	private static final ThreadPoolExecutor _threadPoolExecutor =
 		new ThreadPoolExecutor(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.kernel.util;
 
-import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -26,9 +25,11 @@ import java.net.UnknownHostException;
 
 import java.util.Enumeration;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Michael C. Han
@@ -41,25 +42,11 @@ public class InetAddressUtil {
 		throws UnknownHostException {
 
 		try {
-			if (_atomicInteger.getAndDecrement() <= 0) {
-				_log.error(
-					"Thread limit exceeded to resolve domain: " + domain);
+			DNSResolveTask dnsResolveTask = new DNSResolveTask(domain);
 
-				return null;
-			}
+			_threadPoolExecutor.execute(dnsResolveTask);
 
-			DefaultNoticeableFuture<InetAddress> defaultNoticeableFuture =
-				new DefaultNoticeableFuture<>(
-					() -> InetAddress.getByName(domain));
-
-			Thread thread = new Thread(
-				defaultNoticeableFuture, "Inet Address Util");
-
-			thread.setDaemon(true);
-
-			thread.start();
-
-			return defaultNoticeableFuture.get(
+			return dnsResolveTask.get(
 				_DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 		}
 		catch (ExecutionException | InterruptedException | TimeoutException
@@ -71,9 +58,6 @@ public class InetAddressUtil {
 
 			throw new UnknownHostException(
 				"Unable to resolve domain: " + domain);
-		}
-		finally {
-			_atomicInteger.incrementAndGet();
 		}
 	}
 
@@ -130,9 +114,48 @@ public class InetAddressUtil {
 	private static final Log _log = LogFactoryUtil.getLog(
 		InetAddressUtil.class);
 
-	private static final AtomicInteger _atomicInteger = new AtomicInteger(
-		GetterUtil.getInteger(
-			PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)));
+	private static final ThreadPoolExecutor _threadPoolExecutor =
+		new ThreadPoolExecutor(
+			1,
+			GetterUtil.getInteger(
+				PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)),
+			60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+			new NamedThreadFactory(
+				"InetAddressUtil DNS Resolve Thread - ", Thread.NORM_PRIORITY,
+				InetAddressUtil.class.getClassLoader()),
+			(runnable, executor) -> {
+				if (!(runnable instanceof DNSResolveTask)) {
+					return;
+				}
+
+				DNSResolveTask dnsResolveTask = (DNSResolveTask)runnable;
+
+				_log.error(
+					"Thread limit exceeded to resolve domain: " +
+						dnsResolveTask.getDomain());
+
+				dnsResolveTask.reject();
+			});
+
+	private static class DNSResolveTask extends FutureTask<InetAddress> {
+
+		public DNSResolveTask(String domain) {
+			super(() -> InetAddress.getByName(domain));
+
+			_domain = domain;
+		}
+
+		public String getDomain() {
+			return _domain;
+		}
+
+		public void reject() {
+			set(null);
+		}
+
+		private final String _domain;
+
+	}
 
 	private static class LocalHostNameHolder {
 


### PR DESCRIPTION
- LPS-X The AtomicInteger should be a field, otherwise the limit won't work
- LPS-X Use a ThreadPoolExecutor to implement the limitation: 1) 1 core thread, max DNS_SECURITY_THREAD_LIMIT threads; 2) no work queue; 3) keeping the original logic when rejected (return null)
- LPS-X Cache the resolved InetAddress; TODO: cache expiration
